### PR TITLE
Feature/monitoring

### DIFF
--- a/alertmanager/config.yml
+++ b/alertmanager/config.yml
@@ -1,0 +1,21 @@
+global:
+  slack_api_url: "slack_api_url"
+
+route:
+  receiver: "slack id"
+  group_by: ["alertname"]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 3h
+  routes:
+    - receiver: "slack id"
+      group_wait: 10s
+      match_re:
+        service: dev
+
+receivers:
+  - name: "slack id"
+    slack_configs:
+      - channel: "channel"
+        icon_emoji: ":pig:"
+        text: "summary: {{ .CommonAnnotations.summary }}\ndescription: {{ .CommonAnnotations.description }}"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -54,10 +54,10 @@ services:
     volumes:
       - ./volumes/elasticsearch:/usr/share/elasticsearch/data
     logging:
-        driver: "json-file"
-        options:
-            max-size: "10k"
-            max-file: "10"
+      driver: "json-file"
+      options:
+        max-size: "10k"
+        max-file: "10"
   logstash:
     build:
       context: .
@@ -104,12 +104,17 @@ services:
     container_name: node-exporter
     image: quay.io/prometheus/node-exporter:latest
     command:
-      - '--path.rootfs=/host'
+      - "--path.procfs=/host/proc"
+      - "--path.sysfs=/host/sys"
+      - "--collector.filesystem.ignored-mount-points"
+      - "^/(sys|proc|dev|host|etc|rootfs/var/lib/docker/containers|rootfs/var/lib/docker/overlay2|rootfs/run/docker/netns|rootfs/var/lib/docker/aufs)($$|/)"
     volumes:
-      - '/:/host:ro,rslave'
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
     ports:
       - 9100:9100
-    expose: 
+    expose:
       - 9100
     networks:
       - mynet
@@ -136,11 +141,12 @@ services:
     container_name: prometheus
     image: prom/prometheus
     volumes:
-      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./prometheus/:/etc/prometheus/
+      - ./prometheus/data:/prometheus
     command:
-      - '--config.file=/etc/prometheus/prometheus.yml'
-      - '--storage.tsdb.path=/prometheus'
-      - '--web.enable-lifecycle'
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.enable-lifecycle"
     ports:
       - 9090:9090
     expose:
@@ -155,13 +161,13 @@ services:
     volumes:
       - ./grafana/data:/var/lib/grafana
       - ./grafana/grafana.ini:/etc/grafana/grafana.ini
-    ports: 
+    ports:
       - 3000:3000
     expose:
       - 3000
     networks:
       - mynet
     restart: always
-      
+
 volumes:
   mysql_data_dev: null

--- a/prometheus/alert.rules
+++ b/prometheus/alert.rules
@@ -1,0 +1,49 @@
+groups:
+- name: alert.rules
+  rules:
+  - alert: InstanceDown
+    expr: up == 0
+    for: 1m
+    labels:
+      severity: "critical"
+    annotations:
+      summary: "Endpoint {{ $labels.instance }} down"
+      description: "{{ $labels.instance }} of job {{ $labels.job }} has been down for more than 1 minutes."
+
+  - alert: HostOutOfMemory
+    expr: node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes * 100 < 10
+    for: 2m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Host out of memory (instance {{ $labels.instance }})"
+      description: "Node memory is filling up (< 10% left)\n  VALUE = {{ $value }}\n  LABELS: {{ $labels }}"
+
+  - alert: HostMemoryUnderMemoryPressure
+    expr: rate(node_vmstat_pgmajfault[1m]) > 1000
+    for: 2m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Host memory under memory pressure (instance {{ $labels.instance }})"
+      description: "The node is under heavy memory pressure. High rate of major page faults\n  VALUE = {{ $value }}\n  LABELS: {{ $labels }}"
+  # Please add ignored mountpoints in node_exporter parameters like
+  # "--collector.filesystem.ignored-mount-points=^/(sys|proc|dev|run)($|/)".
+  # Same rule using "node_filesystem_free_bytes" will fire when disk fills for non-root users.
+  - alert: HostOutOfDiskSpace
+    expr: (node_filesystem_avail_bytes * 100) / node_filesystem_size_bytes < 10 and ON (instance, device, mountpoint) node_filesystem_readonly == 0
+    for: 2m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Host out of disk space (instance {{ $labels.instance }})"
+      description: "Disk is almost full (< 10% left)\n  VALUE = {{ $value }}\n  LABELS: {{ $labels }}"
+
+  - alert: HostHighCpuLoad
+    expr: 100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle"}[2m])) * 100) > 80
+    for: 0m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Host high CPU load (instance {{ $labels.instance }})"
+      description: "CPU load is > 80%\n  VALUE = {{ $value }}\n  LABELS: {{ $labels }}"

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,50 +1,49 @@
 # my global config
 global:
-  scrape_interval:     15s # By default, scrape targets every 15 seconds.
+  scrape_interval: 15s # By default, scrape targets every 15 seconds.
   evaluation_interval: 15s # By default, scrape targets every 15 seconds.
   # scrape_timeout is set to the global default (10s).
 
   # Attach these labels to any time series or alerts when communicating with
   # external systems (federation, remote storage, Alertmanager).
   external_labels:
-      monitor: 'my-project'
+    monitor: "my-project"
 
 # Load and evaluate rules in this file every 'evaluation_interval' seconds.
-# rule_files:
-#   - 'alert.rules'
+rule_files:
+  - "alert.rules"
   # - "first.rules"
   # - "second.rules"
 
 # alert
-# alerting:
-#   alertmanagers:
-#   - scheme: http
-#     static_configs:
-#     - targets:
-#       - "alertmanager:9093"
+alerting:
+  alertmanagers:
+    - scheme: http
+      static_configs:
+        - targets:
+            - "alertmanager:9093"
 
 # A scrape configuration containing exactly one endpoint to scrape:
 # Here it's Prometheus itself.
 scrape_configs:
   # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
 
-  - job_name: 'prometheus'
+  - job_name: "prometheus"
 
     # Override the global default and scrape targets from this job every 5 seconds.
     scrape_interval: 10s
 
     static_configs:
-         - targets: ['localhost:9090']
+      - targets: ["localhost:9090"]
 
-
-  - job_name: 'cadvisor'
+  - job_name: "cadvisor"
     static_configs:
-      - targets: ['cadvisor:8080']
+      - targets: ["cadvisor:8080"]
 
-  - job_name: 'node-exporter'
+  - job_name: "node-exporter"
 
     # Override the global default and scrape targets from this job every 5 seconds.
     scrape_interval: 5s
 
     static_configs:
-      - targets: ['node-exporter:9100']
+      - targets: ["node-exporter:9100"]


### PR DESCRIPTION
## 개요
slack 알림을 받기 위한 모니터링에 alertmanager을 추가

## 작업사항
1. slack 웹훅 url을 받아 모니터링 도중 지정한 조건이 되었을 때 알람이 가도록 함
2. 알람의 기능은 앞으로도 추가 가능하지만 현재 5개로 설정 알람에 대해서는 확정되면 README에 추가할 예정입니다.

## 변경사항
alertmanager 폴더 추가
docker-compose.yml에 내용 추가